### PR TITLE
pprint, vgrind - return non-zero exit status in more cases.  Document.

### DIFF
--- a/pprint.1
+++ b/pprint.1
@@ -146,6 +146,9 @@ specifies a point size
 to use on output (exactly the same as the argument
 of a .ps)
 .El
+.Sh EXIT STATUS
+0 on normal exit, >0 for some errors.  Errors are not always reflected
+in the exit status.
 .Sh FILES
 .Bl -tag -width /usr/share/misc/vgrindefsxx -compact
 .It Pa index
@@ -163,7 +166,7 @@ language descriptions (either the text or db version of vgrindefs is present.)
 .Xr groff 1 ,
 .Xr getcap 3 ,
 .Xr troff 1 ,
-.Xr vgrind 1 ,
+.Xr vgrind 1
 .Sh HISTORY
 The
 .Nm
@@ -213,6 +216,8 @@ works best if it is run from the directory of the files being
 formatted or a directory immediately above.  Run from a remote
 directory, it produces long garbled headers. 
 .Pp
+Due to the limitations of csh, error detection and processing is
+unreliable; an error does not always result in a non-zero return code.
 .Pp
 The mechanism of
 .Xr ctags 1

--- a/pprint.sh.in
+++ b/pprint.sh.in
@@ -75,7 +75,7 @@ while ($#argv > 0)
 	    echo "vgrind: $1:q option must have argument"
 	    exit 1
 	else
-	    set options=( $options:q -h $2:q )
+	    set options=($options:q -h $2:q)
 	    shift
 	    shift
 	    breaksw
@@ -95,7 +95,11 @@ end
 
 if ($f == 'filter') then
     $vf $options:q $files | cat $tm/$vmacs -
+    set rc=$status
 else
     $vf $options:q $files |\
 	groff -T pdf -C -i $voptions:q -M $tm -mvgrind
+    set rc=$status
 endif
+
+exit $rc

--- a/vgrind.1
+++ b/vgrind.1
@@ -190,6 +190,9 @@ option and the file
 .Pa index
 as argument.
 .El
+.Sh EXIT STATUS
+0 on normal exit, >0 for some errors.  Errors are not always reflected
+in the exit status.
 .Sh FILES
 .Bl -tag -width /usr/share/misc/vgrindefsxx -compact
 .It Pa index
@@ -259,6 +262,9 @@ automatically sends its output to a printer.  Producing a PDF or
 HTML/CSS file by default (see the
 .Fl t 
 option) might be better for modern usage.
+.Pp
+Due to the limitations of csh, error detection and processing is
+unreliable; an error does not always result in a non-zero return code.
 .Pp
 The mechanism of
 .Xr ctags 1

--- a/vgrind.sh.in
+++ b/vgrind.sh.in
@@ -99,6 +99,7 @@ while ($#argv > 0)
     endsw
 end
 
+set rc=0
 if (-r index) then
     echo > nindex
     foreach i ($files)
@@ -110,16 +111,20 @@ if (-r index) then
     if ($f == 'filter') then
 	if ("$head" != "") then
 	    $vf $options -h "$head" $files | cat $tm/$vmacs -
+	    set rc=$status
 	else
 	    $vf $options $files | cat $tm/$vmacs -
+	    set rc=$status
 	endif
     else
 	if ("$head" != "") then
 	    $vf $options -h "$head" $files | \
 		sh -c "groff -Tps $lpoption -C -rx1 $voptions -i -M $tm -mvgrind 2>> xindex"
+	    set rc=$status
 	else
 	    $vf $options $files | \
 		sh -c "groff -Tps $lpoption -C -rx1 $voptions -i -M $tm -mvgrind 2>> xindex"
+	    set rc=$status
 	endif
     endif
     sort -df +0 -2 xindex >index
@@ -128,14 +133,20 @@ else
     if ($f == 'filter') then
 	if ("$head" != "") then
 	    $vf $options -h "$head" $files | cat $tm/$vmacs -
+	    set rc=$status
 	else
 	    $vf $options $files | cat $tm/$vmacs -
+	    set rc=$status
 	endif
     else
 	if ("$head" != "") then
 	    $vf $options -h "$head" $files | groff -Tps $lpoption -C -i $voptions -M $tm -mvgrind
+	    set rc=$status
 	else
 	    $vf $options $files | groff -Tps $lpoption -C -i $voptions -M $tm -mvgrind
+	    set rc=$status
 	endif
     endif
 endif
+
+exit $rc


### PR DESCRIPTION
# pprint, vgrind
- Return non-zero exit status in more error cases
- Get rid of superfluous spaces in pprint array assignment

# pprint.1, vgrind.1
- Add "EXIT STATUS" section
- Note that the exit status isn't always correct
- pprint.1: remove trailing comma in "SEE ALSO" list